### PR TITLE
Bug 1837421: Allow to set custom permissions for the mounted folder

### DIFF
--- a/cmd/nfsplugin/main.go
+++ b/cmd/nfsplugin/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/spf13/cobra"
 
@@ -29,6 +30,7 @@ import (
 var (
 	endpoint string
 	nodeID   string
+	perm     string
 )
 
 func init() {
@@ -55,6 +57,8 @@ func main() {
 	cmd.PersistentFlags().StringVar(&endpoint, "endpoint", "", "CSI endpoint")
 	cmd.MarkPersistentFlagRequired("endpoint")
 
+	cmd.PersistentFlags().StringVar(&perm, "mount-permissions", "", "mounted folder permissions")
+
 	cmd.ParseFlags(os.Args[1:])
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%s", err.Error())
@@ -65,6 +69,17 @@ func main() {
 }
 
 func handle() {
-	d := nfs.NewNFSdriver(nodeID, endpoint)
+	// Converting string permission representation to uint32
+	var parsedPerm uint64
+	if perm != "" {
+		var err error
+		parsedPerm, err = strconv.ParseUint(perm, 8, 32)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s", err.Error())
+			os.Exit(1)
+		}
+	}
+
+	d := nfs.NewNFSdriver(nodeID, endpoint, uint32(parsedPerm))
 	d.Run()
 }

--- a/pkg/nfs/nfs.go
+++ b/pkg/nfs/nfs.go
@@ -29,6 +29,8 @@ type nfsDriver struct {
 
 	endpoint string
 
+	perm uint32
+
 	//ids *identityServer
 	ns    *nodeServer
 	cap   []*csi.VolumeCapability_AccessMode
@@ -43,7 +45,7 @@ var (
 	version = "1.0.0-rc2"
 )
 
-func NewNFSdriver(nodeID, endpoint string) *nfsDriver {
+func NewNFSdriver(nodeID, endpoint string, perm uint32) *nfsDriver {
 	glog.Infof("Driver: %v version: %v", driverName, version)
 
 	n := &nfsDriver{
@@ -51,6 +53,7 @@ func NewNFSdriver(nodeID, endpoint string) *nfsDriver {
 		version:  version,
 		nodeID:   nodeID,
 		endpoint: endpoint,
+		perm:     perm,
 	}
 
 	n.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER})

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -73,6 +73,12 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
+	if ns.Driver.perm != 0 {
+		if err := os.Chmod(targetPath, os.FileMode(ns.Driver.perm)); err != nil {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
+	}
+
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 


### PR DESCRIPTION
For RWX volume, kubelet does not perform recursive ownership/permission change. The heuristics that kubelet uses is being modified via - https://github.com/kubernetes/enhancements/issues/1682

Having said that, for RWX volumes which are made available via NFS protocol, using fsGroup is not recommended because if there are 2 pods that are trying to use same volume but with different fsGroup then one pod may lock out the other pod.

To avoid this, we must be able to set the folder permissions to 0777. This commit adds a cli option --mount-permissions, that allows to define custom permissions. If the value is not specified, then default permissions will be kept.
    
Cherry-picked from: https://github.com/kubernetes-csi/csi-driver-nfs/pull/36