### PR TITLE
Bug 1916164: Updating csi-driver-nfs builder & base images to be consistent with ART

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7
 COPY . /go/src/github.com/openshift/csi-driver-nfs
 RUN cd /go/src/github.com/openshift/csi-driver-nfs && \
     go build -o /go/src/github.com/openshift/csi-driver-nfs/nfsplugin cmd/nfsplugin/main.go
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 
 COPY --from=0 /go/src/github.com/openshift/csi-driver-nfs/nfsplugin /usr/bin/
 


### PR DESCRIPTION
Updating csi-driver-nfs builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/csi-driver-nfs.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.