### PR TITLE
Windows go version

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -15,4 +15,6 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
     - name: Run unit tests
-      run: go test -v -race ./pkg/...
+      run: |
+        go version
+        go test -v -race ./pkg/...

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -21,6 +21,7 @@ jobs:
 
     - name: Build Test
       run: |
+        go version
         export PATH=$PATH:$HOME/.local/bin
         make verify
         go test -covermode=count -coverprofile=profile.cov ./pkg/...

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -18,4 +18,5 @@ jobs:
         uses: actions/checkout@v2
       - name: Run Windows Unit Tests
         run: |
+          go version
           go test -v -race ./pkg/...

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -6,12 +6,12 @@ jobs:
   build:
     strategy:
       matrix:
-        go-versions: [1.16.x]
+        go-versions: [^1.16]
         platform: [windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code


### PR DESCRIPTION

/kind failing-test


**What this PR does / why we need it**:
Prior to this patch, the Go version for the Windows tests in Github
actions was set as `1.16.x`, which [mysteriously resolved to
`1.15.15`][1].

With this patch, the Go version for the Windows tests is set as a semver
range.

This patch also bumps `actions/setup-go`[2] to the latest version,
consistent with the other platforms.

Lastly, in order to rapidly debug test issues, issue `go version` prior to
running any test.

[1]: https://github.com/kubernetes-csi/csi-driver-nfs/runs/4211323920?check_suite_focus=true
[2]: https://github.com/actions/setup-go

**Does this PR introduce a user-facing change?**:
```release-note
none
```
