### PR TITLE
OCPBUGS-34363: Updating csi-driver-nfs-container image to be consistent with ART for 4.17

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.21-openshift-4.17
+  tag: rhel-9-release-golang-1.22-openshift-4.17

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-csi/csi-driver-nfs
 
-go 1.21
+go 1.22
 
 require (
 	github.com/container-storage-interface/spec v1.8.0

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17
 COPY . /go/src/github.com/openshift/csi-driver-nfs
 RUN cd /go/src/github.com/openshift/csi-driver-nfs && \
     go build -o /go/src/github.com/openshift/csi-driver-nfs/nfsplugin cmd/nfsplugin/main.go

--- a/vendor/k8s.io/kubernetes/test/e2e/framework/testfiles/testdata/a/foo.txt
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/testfiles/testdata/a/foo.txt
@@ -1,1 +1,0 @@
-Hello World


### PR DESCRIPTION
Manual bump of csi-driver-nfs-container image to be consistent with ART for 4.17.
Replaces #143 as a vendoring change was necessary after bumping the version of go.