### PR TITLE
CARRY: Use base images with Go v1.22

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.21-openshift-4.17
+  tag: rhel-9-release-golang-1.22-openshift-4.17

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17
 COPY . /go/src/github.com/openshift/csi-driver-nfs
 RUN cd /go/src/github.com/openshift/csi-driver-nfs && \
     go build -o /go/src/github.com/openshift/csi-driver-nfs/nfsplugin cmd/nfsplugin/main.go


### PR DESCRIPTION
Upstream has made the bump already.

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Upgrade the base images to Go v1.22, as the upstream repository has Go v1.22 defined in its go.mod.

```release-note
none
```
